### PR TITLE
Feature/0.1.2

### DIFF
--- a/ble_orchestrator/__init__.py
+++ b/ble_orchestrator/__init__.py
@@ -2,4 +2,4 @@
 BLE Orchestrator - BLE操作を集約して制御する常駐型サービス
 """
 
-__version__ = "0.1.0" 
+__version__ = "0.1.2"

--- a/ble_orchestrator/orchestrator/config.py
+++ b/ble_orchestrator/orchestrator/config.py
@@ -31,9 +31,11 @@ LOG_BACKUP_COUNT = int(os.environ.get("BLE_ORCHESTRATOR_LOG_BACKUP_COUNT", "5"))
 # BLE設定
 SCAN_INTERVAL_SEC = 0.5  # スキャン間隔（秒）
 SCAN_CACHE_TTL_SEC = 300.0  # スキャン結果キャッシュ保持時間（秒）- 5分に延長
-BLE_CONNECT_TIMEOUT_SEC = 10.0  # 接続タイムアウト（秒）
+BLE_CONNECT_TIMEOUT_SEC = float(os.environ.get("BLE_ORCHESTRATOR_CONNECT_TIMEOUT", "20.0"))  # 接続タイムアウト（秒）- サービス発見に十分な時間を確保
 BLE_RETRY_COUNT = 2  # 接続リトライ回数
 BLE_RETRY_INTERVAL_SEC = 1.0  # リトライ間隔（秒）
+# 接続後のサービス発見完了待機時間（秒）- SwitchBot等のデバイスでサービス発見が完了するまで待機
+BLE_POST_CONNECT_WAIT_SEC = float(os.environ.get("BLE_ORCHESTRATOR_POST_CONNECT_WAIT", "0.5"))
 
 # BLEアダプタ設定
 BLE_ADAPTERS = ["hci0", "hci1"]  # 使用するBLEアダプタのリスト

--- a/ble_orchestrator/orchestrator/config.py
+++ b/ble_orchestrator/orchestrator/config.py
@@ -31,13 +31,35 @@ LOG_BACKUP_COUNT = int(os.environ.get("BLE_ORCHESTRATOR_LOG_BACKUP_COUNT", "5"))
 # BLE設定
 SCAN_INTERVAL_SEC = 0.5  # スキャン間隔（秒）
 SCAN_CACHE_TTL_SEC = 300.0  # スキャン結果キャッシュ保持時間（秒）- 5分に延長
-BLE_CONNECT_TIMEOUT_SEC = float(os.environ.get("BLE_ORCHESTRATOR_CONNECT_TIMEOUT", "20.0"))  # 接続タイムアウト（秒）- サービス発見に十分な時間を確保
-BLE_RETRY_COUNT = 2  # 接続リトライ回数
-BLE_RETRY_INTERVAL_SEC = 1.0  # リトライ間隔（秒）
+
+# 接続タイムアウト（秒）- サービス発見に十分な時間を確保
+BLE_CONNECT_TIMEOUT_SEC = float(
+    os.environ.get("BLE_ORCHESTRATOR_CONNECT_TIMEOUT", "20.0")
+)
+
+# 接続リトライ回数/間隔（環境変数で調整可能）
+BLE_RETRY_COUNT = int(os.environ.get("BLE_ORCHESTRATOR_RETRY_COUNT", "2"))
+BLE_RETRY_INTERVAL_SEC = float(
+    os.environ.get("BLE_ORCHESTRATOR_RETRY_INTERVAL", "1.0")
+)
+
 # 接続後のサービス発見完了待機時間（秒）- SwitchBot等のデバイスでサービス発見が完了するまで待機
-BLE_POST_CONNECT_WAIT_SEC = float(os.environ.get("BLE_ORCHESTRATOR_POST_CONNECT_WAIT", "0.5"))
+BLE_POST_CONNECT_WAIT_SEC = float(
+    os.environ.get("BLE_ORCHESTRATOR_POST_CONNECT_WAIT", "0.5")
+)
+
+# 接続前の到達可能性チェック（pre-connect find）設定
+# 有効にすると、BleakClientでの本接続前に簡易スキャンを実行して到達可能性を確認する
+ENABLE_PRECONNECT_FIND = (
+    os.environ.get("BLE_ORCHESTRATOR_ENABLE_PRECONNECT_FIND", "0") == "1"
+)
+PRECONNECT_FIND_TIMEOUT_SEC = float(
+    os.environ.get("BLE_ORCHESTRATOR_PRECONNECT_FIND_TIMEOUT", "2.0")
+)
 
 # BLEアダプタ設定
+# 複数アダプタ構成の場合はスキャン用と接続用を分離することを推奨。
+# 単一アダプタ環境などでは、運用ポリシーに応じて両方を同じアダプタに設定してもよい。
 BLE_ADAPTERS = ["hci0", "hci1"]  # 使用するBLEアダプタのリスト
 DEFAULT_SCAN_ADAPTER = "hci0"  # スキャン用のデフォルトアダプタ
 DEFAULT_CONNECT_ADAPTER = "hci1"  # 接続用のデフォルトアダプタ

--- a/ble_orchestrator/orchestrator/handler.py
+++ b/ble_orchestrator/orchestrator/handler.py
@@ -8,10 +8,18 @@ import logging
 import time
 from typing import Any, Dict, Optional, cast, Union
 
-from bleak import BleakClient, BleakError
+from bleak import BleakClient, BleakError, BleakScanner
 from bleak.backends.device import BLEDevice
 
-from .config import BLE_CONNECT_TIMEOUT_SEC, BLE_RETRY_COUNT, BLE_RETRY_INTERVAL_SEC, DEFAULT_CONNECT_ADAPTER, BLE_POST_CONNECT_WAIT_SEC
+from .config import (
+    BLE_CONNECT_TIMEOUT_SEC,
+    BLE_RETRY_COUNT,
+    BLE_RETRY_INTERVAL_SEC,
+    DEFAULT_CONNECT_ADAPTER,
+    BLE_POST_CONNECT_WAIT_SEC,
+    ENABLE_PRECONNECT_FIND,
+    PRECONNECT_FIND_TIMEOUT_SEC,
+)
 from .types import (
     BLERequest, ReadRequest, ScanRequest, WriteRequest, RequestStatus, 
     NotificationRequest
@@ -46,6 +54,32 @@ class BLERequestHandler:
         self._last_error = None
         self._consecutive_failures = 0
         self._exclusive_control_enabled = True  # 排他制御の有効/無効フラグ
+
+        # 直近のプレ接続チェック結果（デバッグ用）
+        self._last_preconnect_info: Optional[Dict[str, Any]] = None
+
+    def _normalize_connect_target(self, device: Any) -> Union[BLEDevice, str]:
+        """
+        get_device_func から返ってきた値を、BleakClient に渡せる型
+        (BLEDevice or MAC アドレス文字列) に正規化する。
+        """
+        # もともと BLEDevice が返ってくる場合はそのまま
+        if isinstance(device, BLEDevice):
+            return device
+
+        # 文字列（MAC アドレス）の場合もそのまま
+        if isinstance(device, str):
+            return device
+
+        # ScanResult など、自前クラスで address 属性を持つものは
+        # その address を文字列として扱う
+        if hasattr(device, "address"):
+            addr = getattr(device, "address")
+            if isinstance(addr, str):
+                return addr
+
+        # ここに来るのは設計想定外のケース
+        raise TypeError(f"Unsupported device type for connection: {type(device)}")
 
     async def handle_request(self, request: BLERequest) -> None:
         """
@@ -208,6 +242,9 @@ class BLERequestHandler:
         if not device:
             raise ValueError(f"Device {request.mac_address} not found")
 
+        # get_device_func からの戻り値を BleakClient に渡せる型に正規化
+        base_target: Union[BLEDevice, str] = self._normalize_connect_target(device)
+
         async with self._connection_lock:
             # 排他制御が有効でスキャナーが設定されている場合
             if self._exclusive_control_enabled and self._scanner:
@@ -230,46 +267,119 @@ class BLERequestHandler:
             try:
                 # BLE操作の排他制御
                 async with _ble_operation_lock:
+                    # 接続前の到達可能性チェック（オプション）。発見した BLEDevice で接続すると安定しやすい
+                    preconnect_info: Optional[Dict[str, Any]] = None
+                    if ENABLE_PRECONNECT_FIND:
+                        try:
+                            preconnect_info = await self._preconnect_check(
+                                request.mac_address
+                            )
+                            self._last_preconnect_info = preconnect_info
+                        except Exception as e:
+                            logger.warning(
+                                f"Preconnect check failed for {request.mac_address}: {e}"
+                            )
+
+                    # find で発見した BLEDevice があればそれで接続、なければ正規化済みターゲットを使用
+                    connect_target: Union[BLEDevice, str] = (
+                        preconnect_info["device"]
+                        if preconnect_info and preconnect_info.get("device") is not None
+                        else base_target
+                    )
+                    connect_address = (
+                        connect_target.address
+                        if isinstance(connect_target, BLEDevice)
+                        else connect_target
+                    )
+
                     for retry in range(BLE_RETRY_COUNT):
                         try:
+                            attempt = retry + 1
+                            connect_start = time.time()
                             logger.debug(
-                                f"Connecting to {device} to read characteristic "
-                                f"{request.characteristic_uuid} (attempt {retry+1}/{BLE_RETRY_COUNT})"
+                                f"Connecting to {connect_address} to read characteristic "
+                                f"{request.characteristic_uuid} (attempt {attempt}/{BLE_RETRY_COUNT})"
                             )
                             
-                            async with BleakClient(device.address, timeout=BLE_CONNECT_TIMEOUT_SEC, adapter=DEFAULT_CONNECT_ADAPTER) as client:
-                                logger.debug(f"Connected to {device}")
+                            async with BleakClient(connect_target, timeout=BLE_CONNECT_TIMEOUT_SEC, adapter=DEFAULT_CONNECT_ADAPTER) as client:
+                                connect_elapsed = time.time() - connect_start
+                                logger.debug(
+                                    f"Connected to {connect_address} (elapsed={connect_elapsed:.2f}s)"
+                                )
                                 
                                 # サービス発見が完了するまで短い待機時間を追加
                                 # SwitchBot等のデバイスでサービス発見中に切断される問題を回避
                                 if BLE_POST_CONNECT_WAIT_SEC > 0:
                                     await asyncio.sleep(BLE_POST_CONNECT_WAIT_SEC)
                                     logger.debug(f"Post-connect wait completed ({BLE_POST_CONNECT_WAIT_SEC}s)")
-                                
                                 value = await client.read_gatt_char(request.characteristic_uuid)
                                 request.response_data = value
                                 request.status = RequestStatus.COMPLETED
                                 
+                                rssi = None
+                                if self._get_scan_data_func:
+                                    try:
+                                        scan_data = self._get_scan_data_func(
+                                            request.mac_address
+                                        )
+                                        if scan_data is not None and hasattr(
+                                            scan_data, "rssi"
+                                        ):
+                                            rssi = scan_data.rssi
+                                    except Exception as e:
+                                        logger.debug(
+                                            f"Failed to get scan data for {request.mac_address}: {e}"
+                                        )
+
+                                # ログ用: device オブジェクトは除外して簡潔に
+                                preconnect_log = (
+                                    {k: v for k, v in preconnect_info.items() if k != "device"}
+                                    if preconnect_info
+                                    else preconnect_info
+                                )
                                 logger.info(
                                     f"Successfully read characteristic {request.characteristic_uuid} "
-                                    f"from {device}: {value.hex() if value else 'None'}"
+                                    f"from {connect_address}: {value.hex() if value else 'None'} "
+                                    f"(attempt={attempt}, rssi={rssi}, "
+                                    f"preconnect={preconnect_log})"
                                 )
                                 return
                                 
                         except (BleakError, asyncio.TimeoutError) as e:
                             error_msg = str(e)
-                            # サービス発見関連のエラーの場合は詳細をログに記録
-                            if "discover services" in error_msg.lower() or "device disconnected" in error_msg.lower():
-                                logger.warning(
-                                    f"Failed to read from {device} (attempt {retry+1}/{BLE_RETRY_COUNT}): "
-                                    f"Service discovery failed or device disconnected - {error_msg}"
-                                )
+
+                            # エラー種別を簡易分類
+                            lower_msg = error_msg.lower()
+                            if isinstance(e, asyncio.TimeoutError) or "timeout" in lower_msg:
+                                error_type = "timeout"
+                            elif "discover services" in lower_msg or "device disconnected" in lower_msg:
+                                error_type = "discovery_or_disconnected"
+                            elif "not found" in lower_msg:
+                                error_type = "device_not_found"
                             else:
-                                logger.warning(
-                                    f"Failed to read from {device} (attempt {retry+1}/{BLE_RETRY_COUNT}): {error_msg}"
-                                )
+                                error_type = "other"
+
+                            preconnect_log_err = (
+                                {k: v for k, v in preconnect_info.items() if k != "device"}
+                                if preconnect_info
+                                else preconnect_info
+                            )
+                            logger.warning(
+                                "Failed to read from %s (attempt=%d/%d, error_type=%s): %s, preconnect=%s",
+                                connect_address,
+                                attempt,
+                                BLE_RETRY_COUNT,
+                                error_type,
+                                error_msg,
+                                preconnect_log_err,
+                            )
+
                             if retry < BLE_RETRY_COUNT - 1:
-                                await asyncio.sleep(BLE_RETRY_INTERVAL_SEC)
+                                # リトライ間隔は指数バックオフ気味に延長（上限あり）
+                                backoff_sec = min(
+                                    BLE_RETRY_INTERVAL_SEC * (2**retry), 5.0
+                                )
+                                await asyncio.sleep(backoff_sec)
                             else:
                                 # 最終試行で失敗した場合、watchdogに通知
                                 if self._notify_watchdog_func:
@@ -297,6 +407,9 @@ class BLERequestHandler:
         if not device:
             raise ValueError(f"Device {request.mac_address} not found")
 
+        # get_device_func からの戻り値を BleakClient に渡せる型に正規化
+        base_target_w: Union[BLEDevice, str] = self._normalize_connect_target(device)
+
         async with self._connection_lock:
             # 排他制御が有効でスキャナーが設定されている場合
             if self._exclusive_control_enabled and self._scanner:
@@ -319,15 +432,44 @@ class BLERequestHandler:
             try:
                 # BLE操作の排他制御
                 async with _ble_operation_lock:
+                    # 接続前の到達可能性チェック（オプション）。発見した BLEDevice で接続すると安定しやすい
+                    preconnect_info_w: Optional[Dict[str, Any]] = None
+                    if ENABLE_PRECONNECT_FIND:
+                        try:
+                            preconnect_info_w = await self._preconnect_check(
+                                request.mac_address
+                            )
+                            self._last_preconnect_info = preconnect_info_w
+                        except Exception as e:
+                            logger.warning(
+                                f"Preconnect check failed for {request.mac_address}: {e}"
+                            )
+
+                    connect_target_w: Union[BLEDevice, str] = (
+                        preconnect_info_w["device"]
+                        if preconnect_info_w and preconnect_info_w.get("device") is not None
+                        else base_target_w
+                    )
+                    connect_address_w = (
+                        connect_target_w.address
+                        if isinstance(connect_target_w, BLEDevice)
+                        else connect_target_w
+                    )
+
                     for retry in range(BLE_RETRY_COUNT):
                         try:
+                            attempt = retry + 1
+                            connect_start = time.time()
                             logger.debug(
-                                f"Connecting to {device.address} to write characteristic "
-                                f"{request.characteristic_uuid} (attempt {retry+1}/{BLE_RETRY_COUNT})"
+                                f"Connecting to {connect_address_w} to write characteristic "
+                                f"{request.characteristic_uuid} (attempt {attempt}/{BLE_RETRY_COUNT})"
                             )
                             
-                            async with BleakClient(device.address, timeout=BLE_CONNECT_TIMEOUT_SEC, adapter=DEFAULT_CONNECT_ADAPTER) as client:
-                                logger.debug(f"Connected to {device.address}")
+                            async with BleakClient(connect_target_w, timeout=BLE_CONNECT_TIMEOUT_SEC, adapter=DEFAULT_CONNECT_ADAPTER) as client:
+                                connect_elapsed = time.time() - connect_start
+                                logger.debug(
+                                    f"Connected to {connect_address_w} (elapsed={connect_elapsed:.2f}s)"
+                                )
                                 
                                 # サービス発見が完了するまで短い待機時間を追加
                                 # SwitchBot等のデバイスでサービス発見中に切断される問題を回避
@@ -349,30 +491,72 @@ class BLERequestHandler:
                                 else:
                                     logger.debug(f"Response not required")
                                     request.response_data = {}
-                                
                                 # リクエスト完了
                                 request.status = RequestStatus.COMPLETED
                                 
+                                rssi = None
+                                if self._get_scan_data_func:
+                                    try:
+                                        scan_data = self._get_scan_data_func(
+                                            request.mac_address
+                                        )
+                                        if scan_data is not None and hasattr(
+                                            scan_data, "rssi"
+                                        ):
+                                            rssi = scan_data.rssi
+                                    except Exception as e:
+                                        logger.debug(
+                                            f"Failed to get scan data for {request.mac_address}: {e}"
+                                        )
+
+                                preconnect_log_w = (
+                                    {k: v for k, v in preconnect_info_w.items() if k != "device"}
+                                    if preconnect_info_w
+                                    else preconnect_info_w
+                                )
                                 logger.info(
                                     f"Successfully wrote to characteristic {request.characteristic_uuid} "
-                                    f"on {device.address}: {request.data.hex() if request.data else 'None'}"
+                                    f"on {connect_address_w}: {request.data.hex() if request.data else 'None'} "
+                                    f"(attempt={attempt}, rssi={rssi}, "
+                                    f"preconnect={preconnect_log_w})"
                                 )
                                 return
                                 
                         except (BleakError, asyncio.TimeoutError) as e:
                             error_msg = str(e)
-                            # サービス発見関連のエラーの場合は詳細をログに記録
-                            if "discover services" in error_msg.lower() or "device disconnected" in error_msg.lower():
-                                logger.warning(
-                                    f"Failed to write to {device.address} (attempt {retry+1}/{BLE_RETRY_COUNT}): "
-                                    f"Service discovery failed or device disconnected - {error_msg}"
-                                )
+
+                            # エラー種別を簡易分類
+                            lower_msg = error_msg.lower()
+                            if isinstance(e, asyncio.TimeoutError) or "timeout" in lower_msg:
+                                error_type = "timeout"
+                            elif "discover services" in lower_msg or "device disconnected" in lower_msg:
+                                error_type = "discovery_or_disconnected"
+                            elif "not found" in lower_msg:
+                                error_type = "device_not_found"
                             else:
-                                logger.warning(
-                                    f"Failed to write to {device.address} (attempt {retry+1}/{BLE_RETRY_COUNT}): {error_msg}"
-                                )
+                                error_type = "other"
+
+                            preconnect_log_err_w = (
+                                {k: v for k, v in preconnect_info_w.items() if k != "device"}
+                                if preconnect_info_w
+                                else preconnect_info_w
+                            )
+                            logger.warning(
+                                "Failed to write to %s (attempt=%d/%d, error_type=%s): %s, preconnect=%s",
+                                connect_address_w,
+                                attempt,
+                                BLE_RETRY_COUNT,
+                                error_type,
+                                error_msg,
+                                preconnect_log_err_w,
+                            )
+
                             if retry < BLE_RETRY_COUNT - 1:
-                                await asyncio.sleep(BLE_RETRY_INTERVAL_SEC)
+                                # リトライ間隔は指数バックオフ気味に延長（上限あり）
+                                backoff_sec = min(
+                                    BLE_RETRY_INTERVAL_SEC * (2**retry), 5.0
+                                )
+                                await asyncio.sleep(backoff_sec)
                             else:
                                 # 最終試行で失敗した場合、watchdogに通知
                                 if self._notify_watchdog_func:
@@ -403,6 +587,55 @@ class BLERequestHandler:
         if not device:
             raise ValueError(f"Device {mac_address} not found")
         return device
+
+    async def _preconnect_check(self, mac_address: str) -> Dict[str, Any]:
+        """
+        接続前の到達可能性チェックを実行し、その結果を返す。
+        戻り値はログ用の簡易ディクショナリであり、接続可否の厳密な判定には使用しない。
+        """
+        info: Dict[str, Any] = {
+            "enabled": ENABLE_PRECONNECT_FIND,
+            "mac_address": mac_address,
+        }
+
+        # スキャンキャッシュから直近情報を取得
+        if self._get_scan_data_func:
+            try:
+                scan_data = self._get_scan_data_func(mac_address)
+                if scan_data is not None:
+                    info["cache_seen"] = True
+                    if hasattr(scan_data, "rssi"):
+                        info["cache_rssi"] = getattr(scan_data, "rssi", None)
+                    if hasattr(scan_data, "timestamp"):
+                        try:
+                            age = time.time() - getattr(scan_data, "timestamp")
+                            info["cache_age_sec"] = round(age, 2)
+                        except Exception:
+                            # timestamp が期待通りでない場合は無視
+                            pass
+                else:
+                    info["cache_seen"] = False
+            except Exception as e:
+                info["cache_error"] = str(e)
+
+        # 簡易 find による到達確認（発見した BLEDevice は接続時に利用するため返す）
+        try:
+            find_start = time.time()
+            found_device = await BleakScanner.find_device_by_address(
+                mac_address,
+                timeout=PRECONNECT_FIND_TIMEOUT_SEC,
+                adapter=DEFAULT_CONNECT_ADAPTER,
+            )
+            elapsed = time.time() - find_start
+            info["find_elapsed_sec"] = round(elapsed, 2)
+            info["find_success"] = found_device is not None
+            if found_device is not None:
+                info["device"] = found_device  # BleakClient は BLEDevice を渡すと接続が安定しやすい
+        except Exception as e:
+            info["find_error"] = str(e)
+
+        logger.debug(f"Preconnect check result for {mac_address}: {info}")
+        return info
 
     def get_consecutive_failures(self) -> int:
         """

--- a/ble_orchestrator/orchestrator/handler.py
+++ b/ble_orchestrator/orchestrator/handler.py
@@ -249,18 +249,9 @@ class BLERequestHandler:
             # 排他制御が有効でスキャナーが設定されている場合
             if self._exclusive_control_enabled and self._scanner:
                 try:
-                    # スキャナー停止を要求
-                    self._scanner.request_scanner_stop()
-                    
-                    # スキャン停止完了を待機（タイムアウト付き）
-                    scan_completed_event = self._scanner.wait_for_scan_completed()
-                    try:
-                        await asyncio.wait_for(scan_completed_event.wait(), timeout=10.0)  # 10秒タイムアウト
-                        scan_completed_event.clear()
-                        logger.debug("Scanner stopped for read operation")
-                    except asyncio.TimeoutError:
-                        logger.warning("Timeout waiting for scanner stop completion, proceeding anyway")
-                        # タイムアウトしても処理を継続
+                    # スキャナー停止を要求し、停止完了まで待機
+                    await self._scanner.stop_for_client(timeout=10.0)
+                    logger.debug("Scanner stopped for read operation")
                 except Exception as e:
                     logger.warning(f"Failed to stop scanner for read operation: {e}")
 
@@ -414,18 +405,9 @@ class BLERequestHandler:
             # 排他制御が有効でスキャナーが設定されている場合
             if self._exclusive_control_enabled and self._scanner:
                 try:
-                    # スキャナー停止を要求
-                    self._scanner.request_scanner_stop()
-                    
-                    # スキャン停止完了を待機（タイムアウト付き）
-                    scan_completed_event = self._scanner.wait_for_scan_completed()
-                    try:
-                        await asyncio.wait_for(scan_completed_event.wait(), timeout=10.0)  # 10秒タイムアウト
-                        scan_completed_event.clear()
-                        logger.debug("Scanner stopped for write operation")
-                    except asyncio.TimeoutError:
-                        logger.warning("Timeout waiting for scanner stop completion, proceeding anyway")
-                        # タイムアウトしても処理を継続
+                    # スキャナー停止を要求し、停止完了まで待機
+                    await self._scanner.stop_for_client(timeout=10.0)
+                    logger.debug("Scanner stopped for write operation")
                 except Exception as e:
                     logger.warning(f"Failed to stop scanner for write operation: {e}")
 

--- a/ble_orchestrator/orchestrator/handler.py
+++ b/ble_orchestrator/orchestrator/handler.py
@@ -11,7 +11,7 @@ from typing import Any, Dict, Optional, cast, Union
 from bleak import BleakClient, BleakError
 from bleak.backends.device import BLEDevice
 
-from .config import BLE_CONNECT_TIMEOUT_SEC, BLE_RETRY_COUNT, BLE_RETRY_INTERVAL_SEC, DEFAULT_CONNECT_ADAPTER
+from .config import BLE_CONNECT_TIMEOUT_SEC, BLE_RETRY_COUNT, BLE_RETRY_INTERVAL_SEC, DEFAULT_CONNECT_ADAPTER, BLE_POST_CONNECT_WAIT_SEC
 from .types import (
     BLERequest, ReadRequest, ScanRequest, WriteRequest, RequestStatus, 
     NotificationRequest
@@ -240,6 +240,12 @@ class BLERequestHandler:
                             async with BleakClient(device.address, timeout=BLE_CONNECT_TIMEOUT_SEC, adapter=DEFAULT_CONNECT_ADAPTER) as client:
                                 logger.debug(f"Connected to {device}")
                                 
+                                # サービス発見が完了するまで短い待機時間を追加
+                                # SwitchBot等のデバイスでサービス発見中に切断される問題を回避
+                                if BLE_POST_CONNECT_WAIT_SEC > 0:
+                                    await asyncio.sleep(BLE_POST_CONNECT_WAIT_SEC)
+                                    logger.debug(f"Post-connect wait completed ({BLE_POST_CONNECT_WAIT_SEC}s)")
+                                
                                 value = await client.read_gatt_char(request.characteristic_uuid)
                                 request.response_data = value
                                 request.status = RequestStatus.COMPLETED
@@ -251,9 +257,17 @@ class BLERequestHandler:
                                 return
                                 
                         except (BleakError, asyncio.TimeoutError) as e:
-                            logger.warning(
-                                f"Failed to read from {device} (attempt {retry+1}): {e}"
-                            )
+                            error_msg = str(e)
+                            # サービス発見関連のエラーの場合は詳細をログに記録
+                            if "discover services" in error_msg.lower() or "device disconnected" in error_msg.lower():
+                                logger.warning(
+                                    f"Failed to read from {device} (attempt {retry+1}/{BLE_RETRY_COUNT}): "
+                                    f"Service discovery failed or device disconnected - {error_msg}"
+                                )
+                            else:
+                                logger.warning(
+                                    f"Failed to read from {device} (attempt {retry+1}/{BLE_RETRY_COUNT}): {error_msg}"
+                                )
                             if retry < BLE_RETRY_COUNT - 1:
                                 await asyncio.sleep(BLE_RETRY_INTERVAL_SEC)
                             else:
@@ -315,6 +329,12 @@ class BLERequestHandler:
                             async with BleakClient(device.address, timeout=BLE_CONNECT_TIMEOUT_SEC, adapter=DEFAULT_CONNECT_ADAPTER) as client:
                                 logger.debug(f"Connected to {device.address}")
                                 
+                                # サービス発見が完了するまで短い待機時間を追加
+                                # SwitchBot等のデバイスでサービス発見中に切断される問題を回避
+                                if BLE_POST_CONNECT_WAIT_SEC > 0:
+                                    await asyncio.sleep(BLE_POST_CONNECT_WAIT_SEC)
+                                    logger.debug(f"Post-connect wait completed ({BLE_POST_CONNECT_WAIT_SEC}s)")
+                                
                                 await client.write_gatt_char(
                                     request.characteristic_uuid, 
                                     request.data,
@@ -340,9 +360,17 @@ class BLERequestHandler:
                                 return
                                 
                         except (BleakError, asyncio.TimeoutError) as e:
-                            logger.warning(
-                                f"Failed to write to {device.address} (attempt {retry+1}): {e}"
-                            )
+                            error_msg = str(e)
+                            # サービス発見関連のエラーの場合は詳細をログに記録
+                            if "discover services" in error_msg.lower() or "device disconnected" in error_msg.lower():
+                                logger.warning(
+                                    f"Failed to write to {device.address} (attempt {retry+1}/{BLE_RETRY_COUNT}): "
+                                    f"Service discovery failed or device disconnected - {error_msg}"
+                                )
+                            else:
+                                logger.warning(
+                                    f"Failed to write to {device.address} (attempt {retry+1}/{BLE_RETRY_COUNT}): {error_msg}"
+                                )
                             if retry < BLE_RETRY_COUNT - 1:
                                 await asyncio.sleep(BLE_RETRY_INTERVAL_SEC)
                             else:

--- a/ble_orchestrator/orchestrator/notification_manager.py
+++ b/ble_orchestrator/orchestrator/notification_manager.py
@@ -161,18 +161,9 @@ class NotificationManager:
                 # 排他制御が有効でスキャナーが設定されている場合
                 if self._exclusive_control_enabled and self._scanner:
                     try:
-                        # スキャナー停止を要求
-                        self._scanner.request_scanner_stop()
-                        
-                        # スキャン停止完了を待機（タイムアウト付き）
-                        scan_completed_event = self._scanner.wait_for_scan_completed()
-                        try:
-                            await asyncio.wait_for(scan_completed_event.wait(), timeout=10.0)  # 10秒タイムアウト
-                            scan_completed_event.clear()
-                            logger.debug("Scanner stopped for notification connection")
-                        except asyncio.TimeoutError:
-                            logger.warning("Timeout waiting for scanner stop completion, proceeding anyway")
-                            # タイムアウトしても処理を継続
+                        # スキャナー停止を要求し、停止完了まで待機
+                        await self._scanner.stop_for_client(timeout=10.0)
+                        logger.debug("Scanner stopped for notification connection")
                     except Exception as e:
                         logger.warning(f"Failed to stop scanner for notification connection: {e}")
                 

--- a/ble_orchestrator/orchestrator/scanner.py
+++ b/ble_orchestrator/orchestrator/scanner.py
@@ -29,16 +29,6 @@ SCANNER_START_TIMEOUT = 10.0
 # スキャナー停止のタイムアウト（秒）
 SCANNER_STOP_TIMEOUT = 10.0
 
-# BLE操作の排他制御用グローバルロック
-_ble_operation_lock = asyncio.Lock()
-
-# スキャナー排他制御用のグローバル変数
-_scanner_stopping = False  # スキャナー停止フラグ
-_client_connecting = False  # クライアント接続中フラグ
-_scan_ready = asyncio.Event()  # スキャン準備完了イベント
-_scan_completed = asyncio.Event()  # スキャン停止完了イベント
-_client_completed = asyncio.Event()  # クライアント完了イベント
-
 class ScanCache:
     """
     スキャン結果のキャッシュを管理するクラス
@@ -232,6 +222,16 @@ class BLEScanner:
         self._loop_activity_timeout = 180.0  # ループ活動タイムアウト（秒）
         self._loop_monitoring_enabled = True  # ループ監視の有効/無効フラグ
 
+        # BLE操作の排他制御用ロック（インスタンス単位）
+        self._ble_operation_lock = asyncio.Lock()
+
+        # スキャナー排他制御用の状態・イベント（インスタンス単位）
+        self._scanner_stopping = False  # スキャナー停止フラグ
+        self._client_connecting = False  # クライアント接続中フラグ
+        self._scan_ready = asyncio.Event()  # スキャン準備完了イベント
+        self._scan_completed = asyncio.Event()  # スキャン停止完了イベント
+        self._client_completed = asyncio.Event()  # クライアント完了イベント
+
     async def _detection_callback(self, device: BLEDevice, adv_data: AdvertisementData) -> None:
         """
         スキャン結果のコールバック
@@ -372,7 +372,7 @@ class BLEScanner:
             logger.info("Recreating scanner")
             
             # BLE操作の排他制御
-            async with _ble_operation_lock:
+            async with self._ble_operation_lock:
                 try:
                     # 現在のスキャナーを停止
                     await self._stop_current_scanner()
@@ -446,8 +446,6 @@ class BLEScanner:
         """
         スキャンループ
         """
-        global _scanner_stopping, _client_connecting, _scan_completed, _client_completed, _scan_ready
-        
         try:
             # スキャンループの開始　スキャンループの終了条件は、スキャン停止イベントが設定されている場合
             while not self._stop_event.is_set():
@@ -455,7 +453,7 @@ class BLEScanner:
                 self._update_loop_activity()
                 
                 # 排他制御が有効な場合、クライアント接続要求をチェック
-                if self._exclusive_control_enabled and _scanner_stopping:
+                if self._exclusive_control_enabled and self._scanner_stopping:
                     logger.info("scan loop: Scanner stop requested for client connection")
                     
                     # スキャン停止前の統計をログ出力
@@ -464,18 +462,18 @@ class BLEScanner:
                     
                     # スキャナーを停止
                     await self._stop_current_scanner()
-                    _scan_completed.set()  # スキャン停止完了を通知
+                    self._scan_completed.set()  # スキャン停止完了を通知
                     
                     # クライアント完了を待機（タイムアウト付き）
                     try:
-                        await asyncio.wait_for(_client_completed.wait(), timeout=CLIENT_COMPLETION_TIMEOUT)
+                        await asyncio.wait_for(self._client_completed.wait(), timeout=CLIENT_COMPLETION_TIMEOUT)
                     except asyncio.TimeoutError:
                         logger.warning("Timeout waiting for client completion, forcing scanner restart")
                         # タイムアウトした場合は強制的にスキャンを再開
                     except asyncio.CancelledError:
                         logger.warning("Scan loop cancelled")
                         break
-                    _client_completed.clear()  # イベントをリセット
+                    self._client_completed.clear()  # イベントをリセット
                     
                     # 停止イベントが設定されている場合は終了
                     if self._stop_event.is_set():
@@ -498,7 +496,7 @@ class BLEScanner:
                         # 再開に失敗した場合は再作成を試行
                         await self._recreate_scanner()
                     
-                    _scan_ready.set()  # スキャン準備完了を通知
+                    self._scan_ready.set()  # スキャン準備完了を通知
                 
                 # スキャナーはコールバック方式なので、待機するだけ
                 await asyncio.sleep(SCAN_INTERVAL_SEC)
@@ -510,9 +508,9 @@ class BLEScanner:
                     if exclusive_duration > self._deadlock_threshold:
                         logger.error(f"POTENTIAL DEADLOCK DETECTED: Exclusive control active for {exclusive_duration:.1f}s")
                         # デッドロックを検出した場合は強制的にリセット
-                        _scanner_stopping = False
-                        _client_connecting = False
-                        _client_completed.set()
+                        self._scanner_stopping = False
+                        self._client_connecting = False
+                        self._client_completed.set()
                         self._exclusive_control_start_time = None
                         logger.warning("Forced reset of exclusive control due to potential deadlock")
                 
@@ -596,9 +594,9 @@ class BLEScanner:
         logger.info("Starting BLE scanner")
         
         # 排他制御用イベントを初期化
-        _scan_ready.clear()
-        _scan_completed.clear()
-        _client_completed.clear()
+        self._scan_ready.clear()
+        self._scan_completed.clear()
+        self._client_completed.clear()
         
         try:
             await asyncio.wait_for(self.scanner.start(), timeout=SCANNER_START_TIMEOUT)
@@ -612,7 +610,7 @@ class BLEScanner:
             logger.info("BLE scanner started successfully")
             
             # スキャン準備完了を通知
-            _scan_ready.set()
+            self._scan_ready.set()
         except asyncio.TimeoutError:
             self.is_running = False
             self._scanner_active = False
@@ -628,20 +626,34 @@ class BLEScanner:
         """
         クライアント接続のためにスキャナー停止を要求
         """
-        global _scanner_stopping, _client_connecting
-        _scanner_stopping = True
-        _client_connecting = True
+        self._scanner_stopping = True
+        self._client_connecting = True
         self._exclusive_control_start_time = time.time()  # 排他制御開始時刻を記録
         logger.info("Scanner stop requested for client connection")
+
+    async def stop_for_client(self, timeout: float = 10.0) -> None:
+        """
+        クライアント接続のためにスキャナーを停止し、停止完了まで待機する高レベルAPI
+        """
+        # 停止を要求
+        self.request_scanner_stop()
+        
+        # スキャン停止完了を待機
+        try:
+            await asyncio.wait_for(self._scan_completed.wait(), timeout=timeout)
+            logger.debug("Scanner stopped for client operation")
+        except asyncio.TimeoutError:
+            logger.warning("Timeout waiting for scanner stop completion, proceeding anyway")
+        finally:
+            self._scan_completed.clear()
 
     def notify_client_completed(self) -> None:
         """
         クライアント処理完了を通知
         """
-        global _scanner_stopping, _client_connecting
-        _client_connecting = False
-        _scanner_stopping = False
-        _client_completed.set()
+        self._client_connecting = False
+        self._scanner_stopping = False
+        self._client_completed.set()
         
         # 排他制御時間をログ出力
         if self._exclusive_control_start_time:
@@ -655,13 +667,13 @@ class BLEScanner:
         """
         スキャン準備完了イベントを取得
         """
-        return _scan_ready
+        return self._scan_ready
 
     def wait_for_scan_completed(self) -> asyncio.Event:
         """
         スキャン停止完了イベントを取得
         """
-        return _scan_completed
+        return self._scan_completed
 
     def set_exclusive_control_enabled(self, enabled: bool) -> None:
         """
@@ -674,7 +686,7 @@ class BLEScanner:
         """
         クライアントが接続中かどうかを確認
         """
-        return _client_connecting
+        return self._client_connecting
 
     async def stop(self) -> None:
         """
@@ -717,7 +729,7 @@ class BLEScanner:
             # これにより、再作成中に停止処理が呼ばれても安全に処理できる
             async with self._recreate_lock:
                 # BLE操作の排他制御
-                async with _ble_operation_lock:
+                async with self._ble_operation_lock:
                     try:
                         # 既存のメソッドを再利用してスキャナーを停止
                         await self._stop_current_scanner()

--- a/doc/SPECIFICATION.md
+++ b/doc/SPECIFICATION.md
@@ -1,7 +1,7 @@
 # BLE Orchestrator 技術仕様書
 
-バージョン: 0.1.0  
-最終更新: 2025-10-24
+バージョン: 0.1.2  
+最終更新: 2026-3-5
 
 ---
 
@@ -646,9 +646,12 @@ class NotificationRequest(BLERequest):
 |---------|---------|-----------|------|
 | `SCAN_INTERVAL_SEC` | - | 0.5 | スキャン間隔（秒） |
 | `SCAN_CACHE_TTL_SEC` | - | 300.0 | キャッシュTTL（秒） |
-| `BLE_CONNECT_TIMEOUT_SEC` | - | 10.0 | 接続タイムアウト |
-| `BLE_RETRY_COUNT` | - | 2 | リトライ回数 |
-| `BLE_RETRY_INTERVAL_SEC` | - | 1.0 | リトライ間隔 |
+| `BLE_CONNECT_TIMEOUT_SEC` | `BLE_ORCHESTRATOR_CONNECT_TIMEOUT` | 20.0 | 接続タイムアウト（秒） |
+| `BLE_RETRY_COUNT` | `BLE_ORCHESTRATOR_RETRY_COUNT` | 2 | リトライ回数 |
+| `BLE_RETRY_INTERVAL_SEC` | `BLE_ORCHESTRATOR_RETRY_INTERVAL` | 1.0 | リトライ間隔（秒） |
+| `BLE_POST_CONNECT_WAIT_SEC` | `BLE_ORCHESTRATOR_POST_CONNECT_WAIT` | 0.5 | 接続直後のサービス発見完了待機時間（秒） |
+| `ENABLE_PRECONNECT_FIND` | `BLE_ORCHESTRATOR_ENABLE_PRECONNECT_FIND` | False | 接続前に簡易スキャンで到達可能性をチェックするか |
+| `PRECONNECT_FIND_TIMEOUT_SEC` | `BLE_ORCHESTRATOR_PRECONNECT_FIND_TIMEOUT` | 2.0 | preconnect find のタイムアウト（秒） |
 | `DEFAULT_SCAN_ADAPTER` | - | "hci0" | スキャン用アダプタ |
 | `DEFAULT_CONNECT_ADAPTER` | - | "hci1" | 接続用アダプタ |
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ble-orchestrator"
-version = "0.1.1"
+version = "0.1.2"
 description = "BLE制御用の常駐サービス"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
# feature/0.1.2 プルリク用・変更内容まとめ

## 概要

v0.1.1 → v0.1.2 の更新で、**BLE接続まわりの安定化**と**スキャナー停止処理の共通化・排他制御の整理**を行っています。

---

## コミット履歴（3件）

1. **5261fec** – v0.1.1 -> v0.1.2（バージョン表記更新）
2. **c975357** – 接続前の到達可能性チェック追加、接続ターゲットの正規化、リトライ回数/間隔の環境変数化
3. **75ba225** – スキャナー停止処理を `stop_for_client` に統一、排他制御の状態・イベントをスキャナーインスタンスで管理するリファクタ

---

## 変更ファイル（7ファイル）

| ファイル | 変更量 | 主な内容 |
|----------|--------|----------|
| `ble_orchestrator/__init__.py` | 2行 | バージョンを 0.1.2 に更新 |
| `ble_orchestrator/orchestrator/config.py` | 約30行 | 接続リトライ・接続前チェック・排他制御の設定追加 |
| `ble_orchestrator/orchestrator/handler.py` | 約+331行（増減含む） | 接続前チェック・正規化・`stop_for_client` 利用・排他制御の有効/無効API |
| `ble_orchestrator/orchestrator/notification_manager.py` | 約15行 | `stop_for_client` 利用・排他制御の有効/無効API |
| `ble_orchestrator/orchestrator/scanner.py` | 約84行変更 | `stop_for_client` 追加、排他制御状態・デッドロック検出をインスタンスで管理 |
| `doc/SPECIFICATION.md` | 約13行 | バージョン 0.1.2、更新日、仕様の微修正 |
| `pyproject.toml` | 2行 | バージョン 0.1.2 に更新 |

---

## 主な変更内容

### 1. BLE接続まわりの強化（handler / config）

- **接続前の到達可能性チェック（pre-connect find）**  
  - 本接続前に簡易スキャンでデバイスが見えるか確認。  
  - 見つかった `BLEDevice` で接続するオプションを追加（環境変数で有効化）。
- **接続ターゲットの正規化**  
  - `get_device_func` の戻り値を `BLEDevice` または MAC 文字列に正規化する `_normalize_connect_target` を追加。ScanResult 等の `address` を持つ型にも対応。
- **リトライの設定を環境変数化**  
  - `BLE_ORCHESTRATOR_RETRY_COUNT` / `BLE_ORCHESTRATOR_RETRY_INTERVAL` でリトライ回数・間隔を変更可能に。
- **接続関連の既存設定**  
  - 接続タイムアウト・接続後待機時間・接続前チェックの有無・タイムアウトなどは引き続き `config.py` および環境変数で管理。

### 2. スキャナー停止処理の統一（handler / notification_manager / scanner）

- **`BLEScanner.stop_for_client(timeout)` の追加**  
  - 「クライアント用にスキャンを止める」処理をこの1メソッドに集約。  
  - 内部で `request_scanner_stop()` し、`_scan_completed` で停止完了を待つ。
- **ハンドラー・通知マネージャーの変更**  
  - 従来の「スキャナー停止要求＋個別待機」を廃止し、read/write/通知接続時に `await self._scanner.stop_for_client(timeout=10.0)` を呼ぶ形に統一。  
  - 重複コード削減と挙動の一貫性を確保。

### 3. 排他制御の整理（scanner / handler / notification_manager）

- **スキャナー側**  
  - 排他制御の状態（`_scanner_stopping` / `_client_connecting`）とイベント（`_scan_completed` / `_client_completed` / `_exclusive_control_start_time`）を `BLEScanner` インスタンスで保持。  
  - `notify_client_completed()` で「クライアント処理完了」を通知し、スキャン再開。  
  - 排他制御が長時間続いた場合のデッドロック検出と強制リセットをスキャンループ内で実施。
- **有効/無効の切り替え**  
  - `BLEScanner` / `BLERequestHandler` / `NotificationManager` に `set_exclusive_control_enabled(enabled)` と `is_exclusive_control_enabled()` を追加。  
  - サービス起動時などに排他制御を一括でオフにする運用が可能（`service.py` で使用）。

### 4. 設定・ドキュメント

- **config.py**  
  - リトライ回数/間隔、接続前チェックの有効/無効・タイムアウト、排他制御の有効/無効・タイムアウトなどを追加・整理。  
  - スキャンキャッシュTTL・リクエスト最大待機時間などの既存値の変更も含む。
- **SPECIFICATION.md**  
  - バージョン 0.1.2、最終更新日、上記に合わせた仕様の記述を更新。

---

## 影響範囲

- **BLE read/write**  
  - 接続前に「pre-connect find」が有効な場合は簡易スキャンを実行。接続ターゲットが正規化され、リトライ回数・間隔が環境変数で変更可能。
- **通知接続**  
  - スキャナー停止は `stop_for_client` 経由に統一。排他制御のオン/オフは `NotificationManager` の API で制御。
- **スキャン**  
  - 排他制御の状態管理とデッドロック検出がスキャナー内に集約。外部からは `stop_for_client` / `notify_client_completed` と排他制御の有効/無効のみを意識する形になる。

---

## レビューポイント（PR本文用の例）

- **排他制御**  
  - `stop_for_client` と `notify_client_completed` の対応関係が、read/write/通知の全パスで抜けなく呼ばれているか。
- **接続まわり**  
  - `_normalize_connect_target` が想定する型（BLEDevice / str / address を持つオブジェクト）で網羅されているか。  
  - pre-connect が有効な場合のタイムアウト・失敗時のフォールバック（正規化済みターゲットでの接続）が意図どおりか。
- **設定**  
  - 新規・変更した環境変数が `config.py` と `SPECIFICATION.md` に一貫して記載されているか。
